### PR TITLE
Made Adjacency a shared_ptr<>

### DIFF
--- a/src/geometry/adjacency.h
+++ b/src/geometry/adjacency.h
@@ -2,16 +2,38 @@
 #define LIBGEODECOMP_GEOMETRY_ADJACENCY_H
 
 #include <libgeodecomp/geometry/coord.h>
-#include <libgeodecomp/geometry/regionbasedadjacency.h>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 
 namespace LibGeoDecomp {
 
-typedef RegionBasedAdjacency Adjacency;
 
-template<typename T>
-boost::shared_ptr<Adjacency> MakeAdjacency(const std::map<Coord<2>, T>& weights)
+class Adjacency
 {
-    boost::shared_ptr<Adjacency> result = boost::make_shared<Adjacency>();
+public:
+    virtual ~Adjacency() {}
+
+    /**
+     * Insert a single edge (from, to) to the graph
+     */
+    virtual void insert(int from, int to) = 0;
+
+    /**
+     * Returns all x \in V with (node, x) \in E.
+     */
+    virtual void getNeighbors(int node, std::vector<int> *neighbors) const = 0;
+
+    /**
+     * Retrieves the number of edges in the adjacency
+     */
+    virtual std::size_t size() const = 0;
+
+};
+
+template<typename ADJACENCY, typename T>
+boost::shared_ptr<ADJACENCY> MakeAdjacency(const std::map<Coord<2>, T>& weights)
+{
+    boost::shared_ptr<ADJACENCY> result = boost::make_shared<ADJACENCY>();
 
     for (typename std::map<Coord<2>, T>::const_iterator it = weights.begin();
         it != weights.end(); ++it) {

--- a/src/geometry/adjacency.h
+++ b/src/geometry/adjacency.h
@@ -9,9 +9,9 @@ namespace LibGeoDecomp {
 typedef RegionBasedAdjacency Adjacency;
 
 template<typename T>
-Adjacency MakeAdjacency(const std::map<Coord<2>, T>& weights)
+boost::shared_ptr<Adjacency> MakeAdjacency(const std::map<Coord<2>, T>& weights)
 {
-    Adjacency result;
+    boost::shared_ptr<Adjacency> result = boost::make_shared<Adjacency>();
 
     for (typename std::map<Coord<2>, T>::const_iterator it = weights.begin();
         it != weights.end(); ++it) {
@@ -21,8 +21,8 @@ Adjacency MakeAdjacency(const std::map<Coord<2>, T>& weights)
             continue;
         }
 
-        result.insert(it->first.x(), it->first.y());
-        result.insert(it->first.y(), it->first.x());
+        result->insert(it->first.x(), it->first.y());
+        result->insert(it->first.y(), it->first.x());
     }
 
     return result;

--- a/src/geometry/partitionmanager.h
+++ b/src/geometry/partitionmanager.h
@@ -212,7 +212,7 @@ public:
 
     const Adjacency& adjacency() const
     {
-        return partition->getAdjacency();
+        return *partition->getAdjacency();
     }
 
     inline unsigned rank() const

--- a/src/geometry/partitions/distributedptscotchunstructuredpartition.h
+++ b/src/geometry/partitions/distributedptscotchunstructuredpartition.h
@@ -247,9 +247,6 @@ private:
                         Coord<2>(16, 10));
                 LOG(DBG, "regions of rank " << i << ": ");
                 LOG(DBG, ss.str());
-
-                std::cout << ss.str() << std::endl;
-
             }
 
             MPILayer().barrier();

--- a/src/geometry/partitions/partition.h
+++ b/src/geometry/partitions/partition.h
@@ -30,7 +30,8 @@ public:
     inline Partition(
         const long offset,
         const std::vector<std::size_t>& weights) :
-        weights(weights)
+        weights(weights),
+        adjacency(new Adjacency())
     {
         startOffsets.resize(weights.size() + 1);
         startOffsets[0] = offset;
@@ -49,7 +50,7 @@ public:
 
     virtual Region<DIM> getRegion(const std::size_t node) const = 0;
 
-    virtual const Adjacency& getAdjacency() const
+    virtual boost::shared_ptr<Adjacency> getAdjacency() const
     {
         return adjacency;
     }
@@ -57,7 +58,7 @@ public:
 protected:
     std::vector<std::size_t> weights;
     std::vector<std::size_t> startOffsets;
-    Adjacency adjacency;
+    boost::shared_ptr<Adjacency> adjacency;
 };
 
 }

--- a/src/geometry/partitions/partition.h
+++ b/src/geometry/partitions/partition.h
@@ -1,7 +1,7 @@
 #ifndef LIBGEODECOMP_GEOMETRY_PARTITIONS_PARTITION_H
 #define LIBGEODECOMP_GEOMETRY_PARTITIONS_PARTITION_H
 
-#include <libgeodecomp/geometry/adjacency.h>
+#include <libgeodecomp/geometry/regionbasedadjacency.h>
 #include <libgeodecomp/geometry/region.h>
 #include <libgeodecomp/misc/stdcontaineroverloads.h>
 
@@ -31,7 +31,7 @@ public:
         const long offset,
         const std::vector<std::size_t>& weights) :
         weights(weights),
-        adjacency(new Adjacency())
+        adjacency(new RegionBasedAdjacency())
     {
         startOffsets.resize(weights.size() + 1);
         startOffsets[0] = offset;

--- a/src/geometry/partitions/ptscotchunstructuredpartition.h
+++ b/src/geometry/partitions/ptscotchunstructuredpartition.h
@@ -28,28 +28,13 @@ public:
             const Coord<DIM>& dimensions,
             const long offset,
             const std::vector<std::size_t>& weights,
-            const Adjacency& adjacency) :
+            boost::shared_ptr<Adjacency> adjacency) :
         Partition<DIM>(offset, weights),
         origin(origin),
         dimensions(dimensions),
         numCells(dimensions.prod())
     {
         this->adjacency = adjacency;
-        buildRegions();
-    }
-
-    PTScotchUnstructuredPartition(
-            const Coord<DIM>& origin,
-            const Coord<DIM>& dimensions,
-            const long offset,
-            const std::vector<std::size_t>& weights,
-            Adjacency&& adjacency) :
-        Partition<DIM>(offset, weights),
-        origin(origin),
-        dimensions(dimensions),
-        numCells(dimensions.prod())
-    {
-        this->adjacency = std::move(adjacency);
         buildRegions();
     }
 
@@ -79,7 +64,7 @@ private:
         SCOTCH_Graph graph;
         int error = SCOTCH_graphInit(&graph);
 
-        SCOTCH_Num numEdges = this->adjacency.size();
+        SCOTCH_Num numEdges = this->adjacency->size();
 
         std::vector<SCOTCH_Num> verttabGra;
         std::vector<SCOTCH_Num> edgetabGra;
@@ -92,7 +77,7 @@ private:
             verttabGra.push_back(currentEdge);
 
             std::size_t before = edgetabGra.size();
-            this->adjacency.getNeighbors(i, &edgetabGra);
+            this->adjacency->getNeighbors(i, &edgetabGra);
 
             currentEdge += edgetabGra.size() - before;
         }

--- a/src/geometry/regionbasedadjacency.cpp
+++ b/src/geometry/regionbasedadjacency.cpp
@@ -11,6 +11,19 @@ RegionBasedAdjacency::RegionBasedAdjacency() :
 
 }
 
+RegionBasedAdjacency::RegionBasedAdjacency(const RegionBasedAdjacency &other) :
+    region(new Region<2>(*other.region))
+{
+
+}
+
+RegionBasedAdjacency &RegionBasedAdjacency::operator=(const RegionBasedAdjacency &other)
+{
+    *region = *other.region;
+    return *this;
+}
+
+
 void RegionBasedAdjacency::insert(int from, int to)
 {
     (*region) << Coord<2>(to, from);

--- a/src/geometry/regionbasedadjacency.h
+++ b/src/geometry/regionbasedadjacency.h
@@ -2,6 +2,7 @@
 #define LIBGEODECOMP_GEOMETRY_REGIONBASEDADJACENCY_H
 
 #include <libgeodecomp/misc/stdcontaineroverloads.h>
+#include <libgeodecomp/geometry/adjacency.h>
 #include <boost/shared_ptr.hpp>
 
 namespace LibGeoDecomp {
@@ -30,7 +31,7 @@ class Region;
  * well as constants for linear merges were 10x worse. That was a show
  * stopper.
  */
-class RegionBasedAdjacency
+class RegionBasedAdjacency : public Adjacency
 {
 public:
     RegionBasedAdjacency();
@@ -46,23 +47,23 @@ public:
     /**
      * Insert a single edge (from, to) to the graph
      */
-    virtual void insert(int from, int to);
+    void insert(int from, int to);
 
     /**
      * Insert all pairs (from, x) with x \in to, to the graph. We sort
      * parameter to to ensure fast, linear inserts.
      */
-    virtual void insert(int from, std::vector<int> to);
+    void insert(int from, std::vector<int> to);
 
     /**
      * Returns all x \in V with (node, x) \in E.
      */
-    virtual void getNeighbors(int node, std::vector<int> *neighbors) const;
+    void getNeighbors(int node, std::vector<int> *neighbors) const;
 
     /**
      * Retrieves the number of edges in the adjacency
      */
-    virtual std::size_t size() const;
+    std::size_t size() const;
 
     const Region<2>& getRegion() const
     {

--- a/src/geometry/regionbasedadjacency.h
+++ b/src/geometry/regionbasedadjacency.h
@@ -34,27 +34,32 @@ class RegionBasedAdjacency
 {
 public:
     RegionBasedAdjacency();
+    RegionBasedAdjacency(const RegionBasedAdjacency &other);
+    RegionBasedAdjacency &operator=(const RegionBasedAdjacency &other);
+    RegionBasedAdjacency(RegionBasedAdjacency &&other) = default;
+    RegionBasedAdjacency &operator=(RegionBasedAdjacency &&other) = default;
+    virtual ~RegionBasedAdjacency() {}
 
     /**
      * Insert a single edge (from, to) to the graph
      */
-    void insert(int from, int to);
+    virtual void insert(int from, int to);
 
     /**
      * Insert all pairs (from, x) with x \in to, to the graph. We sort
      * parameter to to ensure fast, linear inserts.
      */
-    void insert(int from, std::vector<int> to);
+    virtual void insert(int from, std::vector<int> to);
 
     /**
      * Returns all x \in V with (node, x) \in E.
      */
-    void getNeighbors(int node, std::vector<int> *neighbors) const;
+    virtual void getNeighbors(int node, std::vector<int> *neighbors) const;
 
     /**
      * Retrieves the number of edges in the adjacency
      */
-    std::size_t size() const;
+    virtual std::size_t size() const;
 
     const Region<2>& getRegion() const
     {

--- a/src/geometry/regionbasedadjacency.h
+++ b/src/geometry/regionbasedadjacency.h
@@ -36,9 +36,12 @@ public:
     RegionBasedAdjacency();
     RegionBasedAdjacency(const RegionBasedAdjacency &other);
     RegionBasedAdjacency &operator=(const RegionBasedAdjacency &other);
+    virtual ~RegionBasedAdjacency() {}
+
+#ifdef LIBGEODECOMP_WITH_CPP14
     RegionBasedAdjacency(RegionBasedAdjacency &&other) = default;
     RegionBasedAdjacency &operator=(RegionBasedAdjacency &&other) = default;
-    virtual ~RegionBasedAdjacency() {}
+#endif // LIBGEODECOMP_WITH_CPP14
 
     /**
      * Insert a single edge (from, to) to the graph

--- a/src/geometry/test/unit/regiontest.h
+++ b/src/geometry/test/unit/regiontest.h
@@ -74,7 +74,7 @@ public:
 
             region << Coord<1>(1);
 
-            Adjacency adjacency;
+            RegionBasedAdjacency adjacency;
             adjacency.insert(1, std::vector<int>{2, 3});
             adjacency.insert(2, std::vector<int>{4, 5, 6});
 
@@ -111,7 +111,7 @@ public:
             region << Coord<1>(1);
             region << Coord<1>(2);
 
-            Adjacency adjacency;
+            RegionBasedAdjacency adjacency;
             adjacency.insert(1, std::vector<int>{2, 3, 7, 8});
             adjacency.insert(2, std::vector<int>{4, 5, 6});
 
@@ -1272,7 +1272,7 @@ public:
             2,
             Coord<2>(20, 20),
             Topologies::Torus<2>::Topology(),
-            Adjacency());
+            RegionBasedAdjacency());
 
         Region<2> expected;
         expected << Streak<2>(Coord<2>(0,   0), 20)

--- a/src/io/initializer.h
+++ b/src/io/initializer.h
@@ -94,9 +94,9 @@ public:
         Random::seed(index);
     }
 
-    virtual Adjacency getAdjacency() const
+    virtual boost::shared_ptr<Adjacency> getAdjacency() const
     {
-        return Adjacency();
+        return boost::make_shared<Adjacency>();
     }
 };
 

--- a/src/io/initializer.h
+++ b/src/io/initializer.h
@@ -5,7 +5,7 @@
 #include <libgeodecomp/misc/apitraits.h>
 #include <libgeodecomp/misc/random.h>
 #include <libgeodecomp/storage/gridbase.h>
-#include <libgeodecomp/geometry/adjacency.h>
+#include <libgeodecomp/geometry/regionbasedadjacency.h>
 
 namespace LibGeoDecomp {
 
@@ -96,7 +96,7 @@ public:
 
     virtual boost::shared_ptr<Adjacency> getAdjacency() const
     {
-        return boost::make_shared<Adjacency>();
+        return boost::make_shared<RegionBasedAdjacency>();
     }
 };
 

--- a/src/parallelization/hiparsimulator.h
+++ b/src/parallelization/hiparsimulator.h
@@ -31,7 +31,7 @@ public:
     boost::shared_ptr<PARTITION_TYPE> operator()(
         const CoordBox<DIM>& box,
         const std::vector<std::size_t>& weights,
-        const Adjacency& /* unused*/)
+        boost::shared_ptr<Adjacency> /* unused*/)
     {
         return boost::make_shared<PARTITION_TYPE>(
             box.origin,
@@ -49,7 +49,7 @@ public:
     boost::shared_ptr<UnstructuredStripingPartition> operator()(
         const CoordBox<1>& box,
         const std::vector<std::size_t>& weights,
-        const Adjacency& /* unused */)
+        boost::shared_ptr<Adjacency> /* unused */)
     {
         return boost::make_shared<UnstructuredStripingPartition>(
             box.origin,
@@ -70,7 +70,7 @@ public:
     boost::shared_ptr<PTScotchUnstructuredPartition<DIM >> operator()(
         const CoordBox<DIM>& box,
         const std::vector<std::size_t>& weights,
-        const Adjacency& adjacency)
+        boost::shared_ptr<Adjacency> adjacency)
     {
         return boost::make_shared<PTScotchUnstructuredPartition<DIM> >(
             box.origin,
@@ -78,19 +78,6 @@ public:
             0,
             weights,
             adjacency);
-    }
-
-    boost::shared_ptr<PTScotchUnstructuredPartition<DIM >> operator()(
-        const CoordBox<DIM>& box,
-        const std::vector<std::size_t>& weights,
-        Adjacency&& adjacency)
-    {
-        return boost::make_shared<PTScotchUnstructuredPartition<DIM> >(
-            box.origin,
-            box.dimensions,
-            0,
-            weights,
-            std::move(adjacency));
     }
 };
 
@@ -101,7 +88,7 @@ public:
     boost::shared_ptr<DistributedPTScotchUnstructuredPartition<DIM >> operator()(
         const CoordBox<DIM>& box,
         const std::vector<std::size_t>& weights,
-        const Adjacency& adjacency)
+        boost::shared_ptr<Adjacency> adjacency)
     {
         return boost::make_shared<DistributedPTScotchUnstructuredPartition<DIM> >(
             box.origin,
@@ -109,19 +96,6 @@ public:
             0,
             weights,
             adjacency);
-    }
-
-    boost::shared_ptr<DistributedPTScotchUnstructuredPartition<DIM >> operator()(
-        const CoordBox<DIM>& box,
-        const std::vector<std::size_t>& weights,
-        Adjacency&& adjacency)
-    {
-        return boost::make_shared<DistributedPTScotchUnstructuredPartition<DIM> >(
-            box.origin,
-            box.dimensions,
-            0,
-            weights,
-            std::move(adjacency));
     }
 };
 

--- a/src/parallelization/nesting/commonstepper.h
+++ b/src/parallelization/nesting/commonstepper.h
@@ -197,9 +197,9 @@ protected:
         notifyPatchProviders(partitionManager->getOuterRim(), ParentType::GHOST,     globalNanoStep());
         notifyPatchProviders(partitionManager->ownRegion(),   ParentType::INNER_SET, globalNanoStep());
 
-        Adjacency adjacency = initializer->getAdjacency();
-        CommonStepperHelpers::AdjacencySetter(*oldGrid, adjacency);
-        CommonStepperHelpers::AdjacencySetter(*newGrid, adjacency);
+        boost::shared_ptr<Adjacency> adjacency = initializer->getAdjacency();
+        CommonStepperHelpers::AdjacencySetter(*oldGrid, *adjacency);
+        CommonStepperHelpers::AdjacencySetter(*newGrid, *adjacency);
         newGrid->setEdge(oldGrid->getEdge());
 
         resetValidGhostZoneWidth();

--- a/src/parallelization/nesting/commonstepper.h
+++ b/src/parallelization/nesting/commonstepper.h
@@ -6,37 +6,6 @@
 
 namespace LibGeoDecomp {
 
-namespace CommonStepperHelpers {
-
-// fixme: merge this with common stepper?
-class AdjacencySetter
-{
-public:
-#ifdef LIBGEODECOMP_WITH_CPP14
-    template<typename ELEMENT_TYPE, std::size_t MATRICES, typename VALUE_TYPE, int C, int SIGMA>
-    AdjacencySetter(UnstructuredGrid<ELEMENT_TYPE, MATRICES, VALUE_TYPE, C, SIGMA>& grid, const Adjacency& adjacency)
-    {
-        std::map<Coord<2>, double> containerAdjacency;
-
-        for (auto& coord : adjacency.getRegion()) {
-            int from = coord.y();
-            int to = coord.x();
-
-            containerAdjacency[Coord<2>(from, to)] = 1.0;
-        }
-
-        grid.setWeights(0, containerAdjacency);
-    }
-#endif
-
-    template<typename CONTAINER>
-    AdjacencySetter(CONTAINER& , const Adjacency& )
-    { }
-
-};
-
-}
-
 /**
  * This class bundles functionality which is commonly required within
  * Stepper implementations, but not necessarily part of a Stepper's
@@ -197,9 +166,6 @@ protected:
         notifyPatchProviders(partitionManager->getOuterRim(), ParentType::GHOST,     globalNanoStep());
         notifyPatchProviders(partitionManager->ownRegion(),   ParentType::INNER_SET, globalNanoStep());
 
-        boost::shared_ptr<Adjacency> adjacency = initializer->getAdjacency();
-        CommonStepperHelpers::AdjacencySetter(*oldGrid, *adjacency);
-        CommonStepperHelpers::AdjacencySetter(*newGrid, *adjacency);
         newGrid->setEdge(oldGrid->getEdge());
 
         resetValidGhostZoneWidth();

--- a/src/testbed/performancetests/main.cpp
+++ b/src/testbed/performancetests/main.cpp
@@ -401,7 +401,7 @@ public:
         std::map<int, ConvexPolytope<Coord<2> > > cells = mapIDs(rawCells, idStreakLength);
 
         // II. Extract Adjacency List from Cells
-        Adjacency adjacency;
+        RegionBasedAdjacency adjacency;
 
         for (std::map<int, ConvexPolytope<Coord<2> > >::iterator  i = cells.begin(); i != cells.end(); ++i) {
             int id = i->first;


### PR DESCRIPTION
This has several benefits. 

First, the Adjacency can be created only once per process and be cached in the Initializer, which was not possible before since the adjacency was returned as an instance and getAdjacency() was called multiple times (at least twice IIRC).

Second, users can define their own adjacencies, which allows them to optimize the getNeighbors() function. It's no longer required to store the entire data in every process, if only a fraction is required.