### PR TITLE
Build issues with Clang-3.8

### DIFF
--- a/src/misc/random.cpp
+++ b/src/misc/random.cpp
@@ -120,8 +120,8 @@ void seedMT(uint32 seed)
     // so-- that's why the only change I made is to restrict to odd seeds.
     //
 
-    register uint32 x = (seed | 1U) & 0xFFFFFFFFU, *s = state;
-    register int    j;
+    uint32 x = (seed | 1U) & 0xFFFFFFFFU, *s = state;
+    int    j;
 
     for(left=0, *s++=x, j=N; --j;
         *s++ = (x*=69069U) & 0xFFFFFFFFU);
@@ -130,8 +130,8 @@ void seedMT(uint32 seed)
 
 uint32 reloadMT()
 {
-    register uint32 *p0=state, *p2=state+2, *pM=state+M, s0, s1;
-    register int    j;
+    uint32 *p0=state, *p2=state+2, *pM=state+M, s0, s1;
+    int    j;
 
     if(left < -1) {
         seedMT(4357U);

--- a/src/storage/unstructuredupdatefunctor.h
+++ b/src/storage/unstructuredupdatefunctor.h
@@ -102,7 +102,7 @@ public:
                 const int cellsToUpdate = i->endX % C;
                 UnstructuredSoAScalarNeighborhood<CELL, MATRICES, ValueType, C, SIGMA>
                     hoodOld(gridOld, i->endX - cellsToUpdate);
-                std::array<CELL, C> cells;
+                FixedArray<CELL, C> cells;
                 Streak<1> cellStreak(Coord<1>(i->endX - cellsToUpdate), i->endX);
 
                 // update SoA grid: copy cells to local buffer, update, copy data back to grid


### PR DESCRIPTION
This PR resolves one warning and one build error with clang in version 3.8 with CPP14 enabled:

- warning: register storage class specifier is deprecated and incompatible with C++1z [-Wdeprecated-register]
- unstructuredupdatefunctor.h:105:37: error: implicit instantiation of undefined template 'std::__1::array<Cell, 4>'

For detailed descriptions see the commit messages.
