### PR TITLE
Resolve unstructured code warnings

### DIFF
--- a/src/examples/spmvmvectorized/main.cpp
+++ b/src/examples/spmvmvectorized/main.cpp
@@ -213,8 +213,8 @@ void runSimulation(int argc, char *argv[])
     if (SIGMA == 1) {
         sim.addWriter(new ASCIIWriter<Cell>("sum", &Cell::sum, outputFrequency));
     } else {
-        auto asciiWriter = new ASCIIWriter<Cell>("sum", &Cell::sum, outputFrequency);
         // fixme
+        // auto asciiWriter = new ASCIIWriter<Cell>("sum", &Cell::sum, outputFrequency);
         // sim.addWriter(new SellSortingWriter<Cell, ASCIIWriter<Cell> >(
         //                   asciiWriter, 0, "sum", &Cell::sum, outputFrequency));
     }

--- a/src/storage/reorderingunstructuredgrid.h
+++ b/src/storage/reorderingunstructuredgrid.h
@@ -147,6 +147,9 @@ public:
 
     typedef std::pair<int, int> IntPair;
 
+    using GridBase<CellType, 1>::saveRegion;
+    using GridBase<CellType, 1>::loadRegion;
+
     const static int DIM = 1;
     const static int SIGMA = DELEGATE_GRID::SIGMA;
     const static int C = DELEGATE_GRID::C;

--- a/src/storage/unstructuredgrid.h
+++ b/src/storage/unstructuredgrid.h
@@ -315,7 +315,7 @@ public:
         }
     }
 
-    inline void loadRegion(const std::vector<ELEMENT_TYPE> buffer, const Region<DIM>& region, const Coord<1>& offset = Coord<DIM>())
+    inline void loadRegion(const std::vector<ELEMENT_TYPE>& buffer, const Region<DIM>& region, const Coord<1>& offset = Coord<DIM>())
     {
         loadRegion(
             buffer,
@@ -325,7 +325,7 @@ public:
     }
 
     template<typename ITER1, typename ITER2>
-    inline void loadRegion(const std::vector<ELEMENT_TYPE> buffer, const ITER1& start, const ITER2& end, int size)
+    inline void loadRegion(const std::vector<ELEMENT_TYPE>& buffer, const ITER1& start, const ITER2& end, int size)
     {
         const ELEMENT_TYPE *source = buffer.data();
 

--- a/src/storage/unstructuredsoagrid.h
+++ b/src/storage/unstructuredsoagrid.h
@@ -359,7 +359,7 @@ public:
         elements.save(start, end, target->data(), size);
     }
 
-    inline void loadRegion(const std::vector<char> source, const Region<DIM>& region, const Coord<DIM>& offset = Coord<DIM>())
+    inline void loadRegion(const std::vector<char>& source, const Region<DIM>& region, const Coord<DIM>& offset = Coord<DIM>())
     {
         typedef SoAGridHelpers::OffsetStreakIterator<typename Region<DIM>::StreakIterator, DIM> StreakIteratorType;
         StreakIteratorType start(region.beginStreak(), Coord<3>(offset.x(), 0, 0));
@@ -369,7 +369,7 @@ public:
     }
 
     template<typename ITER1, typename ITER2>
-    inline void loadRegion(const std::vector<char> source, const ITER1& start, const ITER2& end, int size)
+    inline void loadRegion(const std::vector<char>& source, const ITER1& start, const ITER2& end, int size)
     {
         elements.load(start, end, source.data(), size);
     }

--- a/src/storage/unstructuredsoagrid.h
+++ b/src/storage/unstructuredsoagrid.h
@@ -121,6 +121,9 @@ class UnstructuredSoAGrid : public GridBase<ELEMENT_TYPE, 1>
 public:
     friend class ReorderingUnstructuredGridTest;
 
+    using GridBase<ELEMENT_TYPE, 1>::saveRegion;
+    using GridBase<ELEMENT_TYPE, 1>::loadRegion;
+
     // fixme: rename VALUE_TYPE to WEIGHT_TYPE
     typedef VALUE_TYPE WeightType;
     const static int DIM = 1;


### PR DESCRIPTION
This PR resolves (all) warnings in the unstructured code. Most of them are -Woverloaded-virtual warnings inside the unstructured grids. This PR also passes a few buffers by reference (instead of copying) where it fits.

For details (e.g. warnings messages) see individual commits. Tested with clang-3.8.