### PR TITLE
Cmake fixes (windows port)

### DIFF
--- a/CMakeModules/CMakeLists.test.txt
+++ b/CMakeModules/CMakeLists.test.txt
@@ -20,7 +20,17 @@ string(REGEX MATCH "^unit"            is_unit_test   ${DIRNAME})
 set(allowed_test false)
 if (is_unit_test)
   set(allowed_test true)
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && pwd && bash -c "${UNITEXEC} ./test")
+  if ("${UNITEXEC}" STREQUAL "")
+  add_custom_target(${TARGET_RUN_UNIT_TEST} 
+  COMMAND echo "running tests in..." & cd
+  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>"
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>"
+  COMMAND start /B test.exe
+  #VERBATIM
+  )
+  else()
+  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." & echo %CD% &echo "Unit ${UNITEXEC}" & start "${UNITEXEC}" test.exe)
+  endif()
 endif()
 
 if (is_hpx_test AND WITH_HPX)
@@ -29,19 +39,19 @@ if (is_hpx_test AND WITH_HPX)
   string(REGEX REPLACE "_.+" "" NUM_LOCALITIES "${NUM_PROC}")
   string(REGEX REPLACE ".+_" "" NUM_THREADS    "${NUM_PROC}")
 
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && pwd && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_LOCALITIES} ./test --hpx:bind=balanced --hpx:threads=${NUM_THREADS} -Ihpx.parcel.tcp.enable=0 -Ihpx.parcel.mpi.enable=1")
+  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_LOCALITIES} ./test --hpx:bind=balanced --hpx:threads=${NUM_THREADS} -Ihpx.parcel.tcp.enable=0 -Ihpx.parcel.mpi.enable=1")
 endif()
 
 if (is_mpi_test AND WITH_MPI)
   set(allowed_test true)
   string(REPLACE "parallel_mpi_" "" NUM_PROC ${DIRNAME})
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && pwd && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_PROC} ${MPIEXEC_PREFLAGS} ./test ${MPIEXEC_POSTFLAGS}")
+  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_PROC} ${MPIEXEC_PREFLAGS} ./test ${MPIEXEC_POSTFLAGS}")
 endif()
 
 if (is_openmp_test AND WITH_THREADS)
   set(allowed_test true)
   string(REPLACE "parallel_openmp_" "" NUM_THREADS ${DIRNAME})
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && pwd && bash -c "OMP_NUM_THREADS=${NUM_THREADS} ${UNITEXEC} ./test")
+  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "OMP_NUM_THREADS=${NUM_THREADS} ${UNITEXEC} ./test")
 endif()
 
 # check whether LIMIT_TESTS selected this path, too

--- a/CMakeModules/CMakeLists.test.txt
+++ b/CMakeModules/CMakeLists.test.txt
@@ -22,17 +22,14 @@ if (is_unit_test)
   set(allowed_test true)
   if ("${UNITEXEC}" STREQUAL "")
   add_custom_target(${TARGET_RUN_UNIT_TEST} 
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>"
   COMMAND echo "running tests in..." & cd
-  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
-  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
   COMMAND start /B test.exe
-  #VERBATIM
   )
   else()
   add_custom_target(${TARGET_RUN_UNIT_TEST}
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>"
   COMMAND echo "running tests in..." & cd
-  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
-  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
   COMMAND echo "Unit ${UNITEXEC}"
   COMMAND start /B "${UNITEXEC}" test.exe)
   endif()
@@ -44,19 +41,28 @@ if (is_hpx_test AND WITH_HPX)
   string(REGEX REPLACE "_.+" "" NUM_LOCALITIES "${NUM_PROC}")
   string(REGEX REPLACE ".+_" "" NUM_THREADS    "${NUM_PROC}")
 
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_LOCALITIES} ./test --hpx:bind=balanced --hpx:threads=${NUM_THREADS} -Ihpx.parcel.tcp.enable=0 -Ihpx.parcel.mpi.enable=1")
+  add_custom_target(${TARGET_RUN_UNIT_TEST}
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>"
+  COMMAND echo "running tests in..." & cd
+  COMMAND start /B "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_LOCALITIES} test.exe --hpx:bind=balanced --hpx:threads=${NUM_THREADS} -Ihpx.parcel.tcp.enable=0 -Ihpx.parcel.mpi.enable=1")
 endif()
 
 if (is_mpi_test AND WITH_MPI)
   set(allowed_test true)
   string(REPLACE "parallel_mpi_" "" NUM_PROC ${DIRNAME})
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_PROC} ${MPIEXEC_PREFLAGS} ./test ${MPIEXEC_POSTFLAGS}")
+  add_custom_target(${TARGET_RUN_UNIT_TEST}
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>"
+  COMMAND echo "running tests in..." & cd 
+  COMMAND start /B "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUM_PROC} ${MPIEXEC_PREFLAGS} test.exe ${MPIEXEC_POSTFLAGS}")
 endif()
 
 if (is_openmp_test AND WITH_THREADS)
   set(allowed_test true)
   string(REPLACE "parallel_openmp_" "" NUM_THREADS ${DIRNAME})
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." && %cd% && bash -c "OMP_NUM_THREADS=${NUM_THREADS} ${UNITEXEC} ./test")
+  add_custom_target(${TARGET_RUN_UNIT_TEST}
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>"
+  COMMAND echo "running tests in..." & cd
+  COMMAND start /B "OMP_NUM_THREADS=${NUM_THREADS} ${UNITEXEC} test.exe")
 endif()
 
 # check whether LIMIT_TESTS selected this path, too

--- a/CMakeModules/CMakeLists.test.txt
+++ b/CMakeModules/CMakeLists.test.txt
@@ -23,13 +23,18 @@ if (is_unit_test)
   if ("${UNITEXEC}" STREQUAL "")
   add_custom_target(${TARGET_RUN_UNIT_TEST} 
   COMMAND echo "running tests in..." & cd
-  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>"
-  COMMAND cd "$<$<CONFIG:Debug>:Debug>"
+  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
   COMMAND start /B test.exe
   #VERBATIM
   )
   else()
-  add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running tests in..." & echo %CD% &echo "Unit ${UNITEXEC}" & start "${UNITEXEC}" test.exe)
+  add_custom_target(${TARGET_RUN_UNIT_TEST}
+  COMMAND echo "running tests in..." & cd
+  COMMAND echo "cd $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
+  COMMAND cd "$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>"
+  COMMAND echo "Unit ${UNITEXEC}"
+  COMMAND start /B "${UNITEXEC}" test.exe)
   endif()
 endif()
 


### PR DESCRIPTION
Changed several linux commands to their windows counterparts to enable unit tests under Windows.