### PR TITLE
Fix issues with HPX 1.4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -335,11 +335,12 @@ endif()
 target_link_libraries(geodecomp ${LIBGEODECOMP_LINK_LIBRARIES})
 
 #============= 6. INSTALLER CONFIG ===================================
+include(GNUInstallDirs)
 install(
   TARGETS geodecomp
   EXPORT ${PACKAGE_NAME}-targets
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib)
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(FILES "${CMAKE_BINARY_DIR}/${PACKAGE_NAME}/config.h" DESTINATION include/${PACKAGE_NAME})
 install(FILES libgeodecomp.h DESTINATION include)

--- a/src/libgeodecomp/communication/hpxreceiver.h
+++ b/src/libgeodecomp/communication/hpxreceiver.h
@@ -10,10 +10,9 @@
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/lcos/broadcast.hpp>
-#include <hpx/lcos/local/receive_buffer.hpp>
+#include <hpx/collectives/broadcast.hpp>
+#include <hpx/local_lcos/receive_buffer.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/util/unwrapped.hpp>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
 #include <libgeodecomp/misc/stringops.h>
 

--- a/src/libgeodecomp/communication/hpxreceiver.h
+++ b/src/libgeodecomp/communication/hpxreceiver.h
@@ -135,7 +135,7 @@ public:
             vec << receiver->get(i).get();
         }
 
-        return std::move(vec);
+        return vec;
     }
 
 private:

--- a/src/libgeodecomp/communication/hpxserializationwrapper.h
+++ b/src/libgeodecomp/communication/hpxserializationwrapper.h
@@ -10,10 +10,10 @@
  * just pull in this header.
  */
 #include <libgeodecomp/communication/hpxserialization.h>
-#include <hpx/runtime/serialization/map.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/runtime/serialization/shared_ptr.hpp>
-#include <hpx/runtime/serialization/vector.hpp>
+#include <hpx/serialization/map.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/shared_ptr.hpp>
+#include <hpx/serialization/vector.hpp>
 
 #endif
 

--- a/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
+++ b/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
@@ -1,9 +1,8 @@
 #include <cxxtest/TestSuite.h>
 #include <hpx/hpx.hpp>
-#include <hpx/lcos/broadcast.hpp>
+#include <hpx/collectives/broadcast.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
-#include <hpx/runtime/serialization/serialize_buffer.hpp>
-#include <hpx/util/unwrapped.hpp>
+#include <hpx/serialization/serialize_buffer.hpp>
 #include <libgeodecomp/communication/hpxreceiver.h>
 #include <libgeodecomp/misc/stringops.h>
 

--- a/src/libgeodecomp/geometry/coord.h
+++ b/src/libgeodecomp/geometry/coord.h
@@ -10,8 +10,8 @@
 #ifdef LIBGEODECOMP_WITH_HPX
 #include <libgeodecomp/misc/cudaboostworkaround.h>
 #include <hpx/config.hpp>
-#include <hpx/runtime/serialization/array.hpp>
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/serialization/array.hpp>
+#include <hpx/serialization/serialize.hpp>
 #endif
 
 // For Intel MPI we need to source mpi.h before stdio.h:

--- a/src/libgeodecomp/io/mocksteerer.h
+++ b/src/libgeodecomp/io/mocksteerer.h
@@ -4,6 +4,11 @@
 #include <sstream>
 #include <libgeodecomp/io/steerer.h>
 
+#ifdef LIBGEODECOMP_WITH_HPX
+#include <hpx/include/threads.hpp>
+#include <hpx/concurrency/spinlock.hpp>
+#endif
+
 namespace LibGeoDecomp {
 
 namespace MockSteererHelpers {

--- a/src/libgeodecomp/io/mockwriter.h
+++ b/src/libgeodecomp/io/mockwriter.h
@@ -8,6 +8,11 @@
 #include <libgeodecomp/misc/clonable.h>
 #include <libgeodecomp/misc/testcell.h>
 
+#ifdef LIBGEODECOMP_WITH_HPX
+#include <hpx/include/threads.hpp>
+#include <hpx/concurrency/spinlock.hpp>
+#endif
+
 #include <sstream>
 
 namespace LibGeoDecomp {

--- a/src/libgeodecomp/misc/clonable.h
+++ b/src/libgeodecomp/misc/clonable.h
@@ -5,7 +5,7 @@
 
 #ifdef LIBGEODECOMP_WITH_HPX
 #include <libgeodecomp/misc/cudaboostworkaround.h>
-#include <hpx/runtime/serialization/base_object.hpp>
+#include <hpx/serialization/base_object.hpp>
 #endif
 
 namespace LibGeoDecomp {

--- a/src/libgeodecomp/misc/nonpodtestcell.h
+++ b/src/libgeodecomp/misc/nonpodtestcell.h
@@ -11,7 +11,7 @@
 #endif
 
 #ifdef LIBGEODECOMP_WITH_HPX
-#include <hpx/runtime/serialization/set.hpp>
+#include <hpx/serialization/set.hpp>
 #endif
 
 namespace LibGeoDecomp {

--- a/src/libgeodecomp/parallelization/hpxsimulator.cpp
+++ b/src/libgeodecomp/parallelization/hpxsimulator.cpp
@@ -3,7 +3,7 @@
 
 #include <libgeodecomp/parallelization/hpxsimulator.h>
 #include <hpx/include/lcos.hpp>
-#include <hpx/lcos/broadcast.hpp>
+#include <hpx/collectives/broadcast.hpp>
 
 namespace LibGeoDecomp {
 namespace HpxSimulatorHelpers {

--- a/src/libgeodecomp/parallelization/hpxsimulator.h
+++ b/src/libgeodecomp/parallelization/hpxsimulator.h
@@ -6,11 +6,10 @@
 
 #include <libgeodecomp/misc/cudaboostworkaround.h>
 #include <hpx/config.hpp>
-#include <hpx/runtime/serialization/set.hpp>
-#include <hpx/runtime/serialization/string.hpp>
-#include <hpx/runtime/serialization/vector.hpp>
-#include <hpx/include/lcos.hpp>
-#include <hpx/lcos/broadcast.hpp>
+#include <hpx/serialization/set.hpp>
+#include <hpx/serialization/string.hpp>
+#include <hpx/serialization/vector.hpp>
+#include <hpx/collectives/broadcast.hpp>
 
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
 #include <libgeodecomp/geometry/partitions/stripingpartition.h>

--- a/src/libgeodecomp/storage/displacedgrid.h
+++ b/src/libgeodecomp/storage/displacedgrid.h
@@ -19,8 +19,8 @@
 #ifdef LIBGEODECOMP_WITH_HPX
 #include <libgeodecomp/misc/cudaboostworkaround.h>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
-#include <hpx/runtime/serialization/input_archive.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
 #endif
 
 namespace LibGeoDecomp {

--- a/src/libgeodecomp/storage/grid.h
+++ b/src/libgeodecomp/storage/grid.h
@@ -26,8 +26,8 @@
 #ifdef LIBGEODECOMP_WITH_HPX
 #include <libgeodecomp/misc/cudaboostworkaround.h>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
-#include <hpx/runtime/serialization/input_archive.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
 #endif
 
 namespace LibGeoDecomp {

--- a/src/libgeodecomp/storage/patchprovider.h
+++ b/src/libgeodecomp/storage/patchprovider.h
@@ -2,7 +2,8 @@
 #define LIBGEODECOMP_STORAGE_PATCHPROVIDER_H
 
 #ifdef LIBGEODECOMP_WITH_HPX
-#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/include/threads.hpp>
+#include <hpx/synchronization/spinlock.hpp>
 #include <mutex>
 #endif
 

--- a/src/libgeodecomp/storage/test/unit/reorderingunstructuredgridtest.h
+++ b/src/libgeodecomp/storage/test/unit/reorderingunstructuredgridtest.h
@@ -19,8 +19,8 @@
 #ifdef LIBGEODECOMP_WITH_HPX
 #include <libgeodecomp/misc/cudaboostworkaround.h>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
-#include <hpx/runtime/serialization/input_archive.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
 #endif
 
 using namespace LibGeoDecomp;


### PR DESCRIPTION
Hi Andi,

the current HPX version is v1.4. Make it compile and fix the use deprecated headers. While here, correct the library install dir.

Thanks, Kurt