### PR TITLE
HPX 1.6 Support

### DIFF
--- a/src/libgeodecomp/misc/scopedtimer.h
+++ b/src/libgeodecomp/misc/scopedtimer.h
@@ -40,7 +40,7 @@ public:
     static double time()
     {
 #ifdef LIBGEODECOMP_WITH_HPX
-        return hpx::util::high_resolution_timer::now();
+        return hpx::chrono::high_resolution_timer::now();
 #else
         return LibFlatArray::benchmark::time();
 #endif


### PR DESCRIPTION
Hi,

this is a single fix to replace deprecated hpx timer interface beginning with version v1.6.0.

Thanks, Kurt
