### PR TITLE
hpx v1.7 support

### DIFF
--- a/CMakeModules/CMakeLists.test.txt
+++ b/CMakeModules/CMakeLists.test.txt
@@ -129,7 +129,11 @@ int main(int argc, char **argv)
     // initial overhead caused by broadcasting the work from one to
     // all other localities:
     std::vector<std::string> config(1, \"hpx.run_hpx_main!=1\");
-    return hpx::init(argc, argv, config);
+
+    hpx::init_params init_args;
+    init_args.cfg = config;
+
+    return hpx::init(argc, argv, init_args);
 }
 ")
   endif()

--- a/src/libgeodecomp/communication/hpxcomponentregsitrationhelper.h
+++ b/src/libgeodecomp/communication/hpxcomponentregsitrationhelper.h
@@ -25,27 +25,27 @@ public:
     virtual ~HPXComponentRegistrator()
     {}
 
-    static hpx::components::component_factory<hpx::components::simple_component<COMPONENT> > *instanceA;
-    static hpx::components::component_registry< hpx::components::simple_component<COMPONENT>, ::hpx::components::factory_check> *instanceB;
+    static hpx::components::component_factory<hpx::components::component<COMPONENT> > *instanceA;
+    static hpx::components::component_registry< hpx::components::component<COMPONENT>, ::hpx::components::factory_check> *instanceB;
 
-    virtual hpx::components::component_factory<hpx::components::simple_component<COMPONENT> > *foo1()
+    virtual hpx::components::component_factory<hpx::components::component<COMPONENT> > *foo1()
     {
-        instanceA = new hpx::components::component_factory<hpx::components::simple_component<COMPONENT> >(0, 0, false);
+        instanceA = new hpx::components::component_factory<hpx::components::component<COMPONENT> >(0, 0, false);
         return instanceA;
     }
 
-    virtual hpx::components::component_registry< hpx::components::simple_component<COMPONENT>, ::hpx::components::factory_check> *foo2()
+    virtual hpx::components::component_registry< hpx::components::component<COMPONENT>, ::hpx::components::factory_check> *foo2()
     {
-        instanceB = new hpx::components::component_registry< hpx::components::simple_component<COMPONENT>, ::hpx::components::factory_check>();
+        instanceB = new hpx::components::component_registry< hpx::components::component<COMPONENT>, ::hpx::components::factory_check>();
         return instanceB;
     }
 };
 
 template<typename COMPONENT>
-hpx::components::component_factory<hpx::components::simple_component<COMPONENT> > *HPXComponentRegistrator<COMPONENT>::instanceA;
+hpx::components::component_factory<hpx::components::component<COMPONENT> > *HPXComponentRegistrator<COMPONENT>::instanceA;
 
 template<typename COMPONENT>
-hpx::components::component_registry< hpx::components::simple_component<COMPONENT>, ::hpx::components::factory_check> *HPXComponentRegistrator<COMPONENT>::instanceB;
+hpx::components::component_registry< hpx::components::component<COMPONENT>, ::hpx::components::factory_check> *HPXComponentRegistrator<COMPONENT>::instanceB;
 
 }
 
@@ -90,10 +90,10 @@ hpx::components::component_registry< hpx::components::simple_component<COMPONENT
     public:                                                             \
         hpx_plugin_exporter_factory()                                   \
         {                                                               \
-            static hpx::util::plugin::concrete_factory< hpx::components::component_factory_base, hpx::components::component_factory<hpx::components::simple_component<TEMPLATE>> > cf; \
+            static hpx::util::plugin::concrete_factory< hpx::components::component_factory_base, hpx::components::component_factory<hpx::components::component<TEMPLATE>> > cf; \
             hpx::util::plugin::abstract_factory<hpx::components::component_factory_base>* w = &cf; \
                                                                         \
-            std::string actname(typeid(hpx::components::simple_component<TEMPLATE>).name()); \
+            std::string actname(typeid(hpx::components::component<TEMPLATE>).name()); \
             boost::algorithm::to_lower(actname);                        \
             LIBGEODECOMP_HPX_PLUGIN_FACTORY()->insert( std::make_pair(actname, w)); \
         }                                                               \
@@ -118,7 +118,7 @@ hpx::components::component_registry< hpx::components::simple_component<COMPONENT
         init_registry_factory_static<TEMPLATE>()                        \
         {                                                               \
             hpx::components::static_factory_load_data_type data = {     \
-                typeid(hpx::components::simple_component<TEMPLATE>).name(), \
+                typeid(hpx::components::component<TEMPLATE>).name(), \
                 LIBGEODECOMP_HPX_PLUGIN_FACTORY                         \
             };                                                          \
             hpx::components::init_registry_factory(data);               \
@@ -135,13 +135,13 @@ hpx::components::component_registry< hpx::components::simple_component<COMPONENT
     namespace hpx {                                                     \
     namespace components {                                              \
                                                                         \
-    template <PARAMS> struct unique_component_name<hpx::components::component_factory<hpx::components::simple_component<TEMPLATE > > > \
+    template <PARAMS> struct unique_component_name<hpx::components::component_factory<hpx::components::component<TEMPLATE > > > \
     {                                                                   \
         typedef char const* type;                                       \
                                                                         \
         static type call(void)                                          \
         {                                                               \
-            return typeid(hpx::components::simple_component<TEMPLATE >).name(); \
+            return typeid(hpx::components::component<TEMPLATE >).name(); \
         }                                                               \
     };                                                                  \
                                                                         \
@@ -162,9 +162,9 @@ hpx::components::component_registry< hpx::components::simple_component<COMPONENT
     public:                                                             \
         hpx_plugin_exporter_registry()                                  \
         {                                                               \
-            static hpx::util::plugin::concrete_factory< hpx::components::component_registry_base, hpx::components::component_registry<hpx::components::simple_component<TEMPLATE>, ::hpx::components::factory_check> > cf; \
+            static hpx::util::plugin::concrete_factory< hpx::components::component_registry_base, hpx::components::component_registry<hpx::components::component<TEMPLATE>, ::hpx::components::factory_check> > cf; \
             hpx::util::plugin::abstract_factory<hpx::components::component_registry_base>* w = &cf; \
-            std::string actname(typeid(hpx::components::simple_component<TEMPLATE>).name()); \
+            std::string actname(typeid(hpx::components::component<TEMPLATE>).name()); \
             boost::algorithm::to_lower(actname);                        \
             LIBGEODECOMP_HPX_PLUGIN_REGISTRY()->insert( std::make_pair(actname, w)); \
         }                                                               \
@@ -181,12 +181,12 @@ hpx::components::component_registry< hpx::components::simple_component<COMPONENT
     namespace components {                                              \
                                                                         \
     template <PARAMS>                                                   \
-    struct unique_component_name<hpx::components::component_registry<hpx::components::simple_component<TEMPLATE >, ::hpx::components::factory_check> > \
+    struct unique_component_name<hpx::components::component_registry<hpx::components::component<TEMPLATE >, ::hpx::components::factory_check> > \
     {                                                                   \
         typedef char const* type;                                       \
         static type call (void)                                         \
         {                                                               \
-            return typeid(hpx::components::simple_component<TEMPLATE >).name(); \
+            return typeid(hpx::components::component<TEMPLATE >).name(); \
         }                                                               \
     };                                                                  \
                                                                         \

--- a/src/libgeodecomp/communication/hpxreceiver.h
+++ b/src/libgeodecomp/communication/hpxreceiver.h
@@ -119,7 +119,7 @@ public:
             )
             {
                 hpx::lcos::broadcast_apply<typename HPXReceiver::receiveAction>(
-                    hpx::util::unwrap(idsFuture), rank, data);
+                    hpx::unwrap(idsFuture), rank, data);
                 return receiverFuture.get();
             },
             HPXReceiver<CARGO>::make(name, rank),

--- a/src/libgeodecomp/communication/hpxreceiver.h
+++ b/src/libgeodecomp/communication/hpxreceiver.h
@@ -12,7 +12,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/collectives/broadcast_direct.hpp>
 #include <hpx/lcos_local/receive_buffer.hpp>
-#include <hpx/runtime/get_ptr.hpp>
+#include <hpx/modules/components.hpp>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
 #include <libgeodecomp/misc/stringops.h>
 

--- a/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
+++ b/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
@@ -1,7 +1,7 @@
 #include <cxxtest/TestSuite.h>
 #include <hpx/hpx.hpp>
 #include <hpx/collectives/broadcast.hpp>
-#include <hpx/runtime/components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/serialization/serialize_buffer.hpp>
 #include <libgeodecomp/communication/hpxreceiver.h>
 #include <libgeodecomp/misc/stringops.h>

--- a/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
+++ b/src/libgeodecomp/communication/test/parallel_hpx_4/hpxreceivertest.h
@@ -119,7 +119,7 @@ public:
         std::string name = "testMultipleReceivers";
         std::shared_ptr<ReceiverType3> receiver = ReceiverType3::make(name, rank).get();
         std::vector<hpx::future<hpx::id_type> > futures = ReceiverType3::find_all(name, size);
-        std::vector<hpx::id_type> ids = hpx::util::unwrap(futures);
+        std::vector<hpx::id_type> ids = hpx::unwrap(futures);
 
         hpx::lcos::broadcast_apply<ReceiverType3::receiveAction>(ids, rank, rank + 0.456);
 

--- a/src/libgeodecomp/parallelization/hpxsimulator.cpp
+++ b/src/libgeodecomp/parallelization/hpxsimulator.cpp
@@ -93,7 +93,7 @@ void gatherAndBroadcastLocalityIndices(
 
     if (hpx::get_locality_id() == 0) {
         std::vector<std::vector<double> > tempGlobalUpdateGroupSpeeds =
-            hpx::util::unwrap(hpx::util::unwrap(hpx::lcos::broadcast<getUpdateGroupSpeeds_action>(localities, basename)));
+            hpx::unwrap(hpx::unwrap(hpx::lcos::broadcast<getUpdateGroupSpeeds_action>(localities, basename)));
 
         std::vector<std::size_t> indices;
         std::vector<double> flattenedUpdateGroupSpeeds;

--- a/src/libgeodecomp/parallelization/hpxsimulator.h
+++ b/src/libgeodecomp/parallelization/hpxsimulator.h
@@ -253,7 +253,7 @@ private:
         for (std::size_t i = localityIndices[rank + 0]; i < localityIndices[rank + 1]; ++i) {
             updateGroupCreationFutures << hpx::async(&HpxSimulator::createUpdateGroup, this, i, partition);
         }
-        updateGroups = hpx::util::unwrap(std::move(updateGroupCreationFutures));
+        updateGroups = hpx::unwrap(std::move(updateGroupCreationFutures));
 
         for (std::size_t i = localityIndices[rank + 0]; i < localityIndices[rank + 1]; ++i) {
             writerAdaptersGhost[i].clear();

--- a/src/libgeodecomp/parallelization/nesting/test/parallel_hpx_4/hpxupdategrouptest.h
+++ b/src/libgeodecomp/parallelization/nesting/test/parallel_hpx_4/hpxupdategrouptest.h
@@ -6,6 +6,8 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/collectives/broadcast.hpp>
 #include <hpx/lcos_local/receive_buffer.hpp>
+#include <hpx/components_base/server/component.hpp>
+#include <hpx/components_base/server/component_base.hpp>
 #include <libgeodecomp/communication/hpxserializationwrapper.h>
 #include <libgeodecomp/geometry/partitions/recursivebisectionpartition.h>
 #include <libgeodecomp/io/testinitializer.h>
@@ -37,7 +39,7 @@ std::string patchProviderName(const std::string& basename, std::size_t sourceRan
 }
 
 template<typename CELL>
-class DummyPatchLinkProvider : public hpx::components::simple_component_base<DummyPatchLinkProvider<CELL> >
+class DummyPatchLinkProvider : public hpx::components::component_base<DummyPatchLinkProvider<CELL> >
 {
 public:
     DummyPatchLinkProvider(std::size_t sourceRank = -1, std::size_t targetRank = -1) :
@@ -66,7 +68,7 @@ private:
 };
 
 template<typename CELL>
-class DummyPatchLinkAccepter : public hpx::components::simple_component_base<DummyPatchLinkAccepter<CELL> >
+class DummyPatchLinkAccepter : public hpx::components::component_base<DummyPatchLinkAccepter<CELL> >
 {
 public:
     DummyPatchLinkAccepter(const std::string& basename = "", std::size_t sourceRank = -1, std::size_t targetRank = -1) :
@@ -112,7 +114,7 @@ private:
  */
 
 template<typename CELL>
-class DummyUpdateGroup : public hpx::components::simple_component_base<DummyUpdateGroup<CELL> >
+class DummyUpdateGroup : public hpx::components::component_base<DummyUpdateGroup<CELL> >
 {
 public:
     DummyUpdateGroup(
@@ -207,15 +209,15 @@ void allDone()
 }
 
 // register component
-typedef hpx::components::simple_component<LibGeoDecomp::DummyPatchLinkAccepter<int> > DummyPatchLinkAccepterType_int;
+typedef hpx::components::component<LibGeoDecomp::DummyPatchLinkAccepter<int> > DummyPatchLinkAccepterType_int;
 HPX_REGISTER_COMPONENT(DummyPatchLinkAccepterType_int, DummyPatchLinkAccepter_int );
-typedef hpx::components::simple_component<LibGeoDecomp::DummyPatchLinkAccepter<std::size_t> > DummyPatchLinkAccepterType_stdSizeT;
+typedef hpx::components::component<LibGeoDecomp::DummyPatchLinkAccepter<std::size_t> > DummyPatchLinkAccepterType_stdSizeT;
 HPX_REGISTER_COMPONENT(DummyPatchLinkAccepterType_stdSizeT, DummyPatchLinkAccepter_stdSizeT );
 
 // register component
-typedef hpx::components::simple_component<LibGeoDecomp::DummyPatchLinkProvider<int> > DummyPatchLinkProviderType_int;
+typedef hpx::components::component<LibGeoDecomp::DummyPatchLinkProvider<int> > DummyPatchLinkProviderType_int;
 HPX_REGISTER_COMPONENT(DummyPatchLinkProviderType_int, DummyPatchLinkProvider_int );
-typedef hpx::components::simple_component<LibGeoDecomp::DummyPatchLinkProvider<std::size_t> > DummyPatchLinkProviderType_stdSizeT;
+typedef hpx::components::component<LibGeoDecomp::DummyPatchLinkProvider<std::size_t> > DummyPatchLinkProviderType_stdSizeT;
 HPX_REGISTER_COMPONENT(DummyPatchLinkProviderType_stdSizeT, DummyPatchLinkProvider_stdSizeT );
 
 // register action
@@ -225,9 +227,9 @@ typedef LibGeoDecomp::DummyPatchLinkProvider<std::size_t>::receive_action DummyP
 HPX_REGISTER_ACTION(DummyPatchLinkProvider_receive_action_stdSizeT);
 
 // register component
-typedef hpx::components::simple_component<LibGeoDecomp::DummyUpdateGroup<int> > DummyUpdateGroupType_int;
+typedef hpx::components::component<LibGeoDecomp::DummyUpdateGroup<int> > DummyUpdateGroupType_int;
 HPX_REGISTER_COMPONENT(DummyUpdateGroupType_int, DummyUpdateGroup_int );
-typedef hpx::components::simple_component<LibGeoDecomp::DummyUpdateGroup<std::size_t> > DummyUpdateGroupType_stdSizeT;
+typedef hpx::components::component<LibGeoDecomp::DummyUpdateGroup<std::size_t> > DummyUpdateGroupType_stdSizeT;
 HPX_REGISTER_COMPONENT(DummyUpdateGroupType_stdSizeT, DummyUpdateGroup_stdSizeT );
 
 // register action


### PR DESCRIPTION
Hey,

this patch set enables libgeodecomp to run with hpx v1.7. Fix deprecation warnings and tests.

Thanks, Kurt